### PR TITLE
change layout.lexers import to just lexers

### DIFF
--- a/repl.py
+++ b/repl.py
@@ -8,7 +8,7 @@ from threading import Thread
 
 from prompt_toolkit import prompt
 from pygments.lexers import LuaLexer
-from prompt_toolkit.layout.lexers import PygmentsLexer
+from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.history import FileHistory
 
 history = FileHistory('.nodemcu-repl_history')


### PR DESCRIPTION
Imports fails (Debian 12) with import from layout.lexers. PygmentsLexer is found in lexers.

I don't know if this is a naming change or Debian specific but the import from fails otherwise.